### PR TITLE
Fix: GitHub deployment workflow merge conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             const d = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref,
+              ref: context.sha,  // Use commit SHA instead of branch ref to avoid merge conflicts
               environment: 'production',
               description: 'Production deployment',
               required_contexts: []  // allow deployment without status checks gating


### PR DESCRIPTION
## Problem Fixed
The GitHub Actions deployment workflow was failing with:
```
Conflict merging main into refs/heads/production
```

## Root Cause
The workflow was using `context.ref` (branch reference) instead of `context.sha` (commit SHA) when creating GitHub deployments. This caused GitHub's deployment API to attempt merging main into production, which failed due to branch conflicts.

## Solution
- Changed from `ref: context.ref` to `ref: context.sha`
- Now uses the exact commit that triggered the workflow
- Prevents merge conflicts during deployment creation

## Impact
- ✅ Fixes deployment failures
- ✅ Ensures reliable production deployments
- ✅ No functional changes to deployment process

Ready for merge to fix the production deployment issue.